### PR TITLE
Upgrade ensmallen to 1.15.0

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,12 @@
+2019-05-20  James Balamuta  <balamut2@illinois.edu>
+
+	* DESCRIPTION (Version, Date): Release 1.15.0
+
+	* NEWS.md: Update for Ensmallen release 1.15.0
+
+	* inst/include/ensmallen_bits: Upgraded to Ensmallen 1.15.0
+	* inst/include/ensmallen.hpp: ditto
+
 2019-05-12  James Balamuta  <balamut2@illinois.edu>
 
 	* DESCRIPTION (Version, Date): Release 1.14.4

--- a/ChangeLog
+++ b/ChangeLog
@@ -4,6 +4,10 @@
 
 	* NEWS.md: Update for Ensmallen release 1.15.0
 
+	* inst/include/ensmallen_bits/spsa: Removed unused `shuffle` parameter.
+
+	* inst/include/ensmallen_bits/qhadam/qhadam_update: Reorder parameter initialization.
+
 	* inst/include/ensmallen_bits: Upgraded to Ensmallen 1.15.0
 	* inst/include/ensmallen.hpp: ditto
 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: RcppEnsmallen
 Title: Header-Only C++ Mathematical Optimization Library for 'Armadillo'
-Version: 0.1.14.4.1
+Version: 0.1.15.0.1
 Authors@R: c(
     person("James Joseph", "Balamuta", email = "balamut2@illinois.edu", 
            role = c("aut", "cre", "cph"), 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Upgraded to ensmallen release 1.15.0 "Wrong Side Of The Road" (2019-05-14)
    - Added QHAdam and QHSGD optimizers ([#81](https://github.com/mlpack/ensmallen/pull/81)).
+- Fix `-Wreorder` in `qhadam` warning ([#115](https://github.com/mlpack/ensmallen/pull/115)).
+- Fix `-Wunused-private-field` warning in `spsa` ([#115](https://github.com/mlpack/ensmallen/pull/115)).
 
 # RcppEnsmallen 0.1.14.4.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# RcppEnsmallen 0.1.15.0.1
+
+- Upgraded to ensmallen release 1.15.0 "Wrong Side Of The Road" (2019-05-14)
+   - Added QHAdam and QHSGD optimizers ([#81](https://github.com/mlpack/ensmallen/pull/81)).
+
 # RcppEnsmallen 0.1.14.4.1
 
 - Upgraded to ensmallen release 1.14.4 "Difficult Crimp" (2019-05-12)

--- a/inst/include/ensmallen.hpp
+++ b/inst/include/ensmallen.hpp
@@ -64,6 +64,7 @@
 #include "ensmallen_bits/ada_delta/ada_delta.hpp"
 #include "ensmallen_bits/ada_grad/ada_grad.hpp"
 #include "ensmallen_bits/adam/adam.hpp"
+#include "ensmallen_bits/qhadam/qhadam.hpp"
 #include "ensmallen_bits/aug_lagrangian/aug_lagrangian.hpp"
 #include "ensmallen_bits/bigbatch_sgd/bigbatch_sgd.hpp"
 #include "ensmallen_bits/cmaes/cmaes.hpp"

--- a/inst/include/ensmallen_bits/ens_version.hpp
+++ b/inst/include/ensmallen_bits/ens_version.hpp
@@ -15,13 +15,13 @@
 #define ENS_VERSION_MAJOR 1
 // The minor version is two digits so regular numerical comparisons of versions
 // work right.  The first minor version of a release is always 10.
-#define ENS_VERSION_MINOR 14
-#define ENS_VERSION_PATCH 4
+#define ENS_VERSION_MINOR 15
+#define ENS_VERSION_PATCH 0
 // If this is a release candidate, it will be reflected in the version name
 // (i.e. the version name will be "RC1", "RC2", etc.).  Otherwise the version
 // name will typically be a seemingly arbitrary set of words that does not
 // contain the capitalized string "RC".
-#define ENS_VERSION_NAME "Difficult Crimp"
+#define ENS_VERSION_NAME "Wrong Side Of The Road"
 
 namespace ens {
 

--- a/inst/include/ensmallen_bits/qhadam/qhadam_impl.hpp
+++ b/inst/include/ensmallen_bits/qhadam/qhadam_impl.hpp
@@ -1,0 +1,44 @@
+/**
+ * @file qhadam_impl.hpp
+ * @author Niteya Shah
+ *
+ * Implementation of QHAdam class wrapper.
+ *
+ * ensmallen is free software; you may redistribute it and/or modify it under
+ * the terms of the 3-clause BSD license.  You should have received a copy of
+ * the 3-clause BSD license along with ensmallen.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef ENSMALLEN_ADAM_QHADAM_IMPL_HPP
+#define ENSMALLEN_ADAM_QHADAM_IMPL_HPP
+
+// In case it hasn't been included yet.
+#include "qhadam.hpp"
+
+namespace ens {
+
+inline QHAdam::QHAdam(
+    const double stepSize,
+    const size_t batchSize,
+    const double v1,
+    const double v2,
+    const double beta1,
+    const double beta2,
+    const double epsilon,
+    const size_t maxIterations,
+    const double tolerance,
+    const bool shuffle,
+    const bool resetPolicy) :
+    optimizer(stepSize,
+              batchSize,
+              maxIterations,
+              tolerance,
+              shuffle,
+              QHAdamUpdate(epsilon, beta1, beta2, v1, v2),
+              NoDecay(),
+              resetPolicy)
+{ /* Nothing to do. */ }
+
+} // namespace ens
+
+ #endif

--- a/inst/include/ensmallen_bits/qhadam/qhadam_update.hpp
+++ b/inst/include/ensmallen_bits/qhadam/qhadam_update.hpp
@@ -34,7 +34,7 @@ namespace ens {
  */
 class QHAdamUpdate
 {
- public:
+public:
   /**
    * Construct the QHAdam update policy with the given parameters.
    *
@@ -50,12 +50,12 @@ class QHAdamUpdate
                const double beta2 = 0.999,
                const double v1 = 0.7,
                const double v2 = 1) :
-    epsilon(epsilon),
-    beta1(beta1),
-    beta2(beta2),
-    v1(v1),
-    v2(v2),
-    iteration(0)
+  epsilon(epsilon),
+  beta1(beta1),
+  beta2(beta2),
+  v1(v1),
+  v2(v2),
+  iteration(0)
   {
     // Nothing to do.
   }
@@ -102,8 +102,8 @@ class QHAdamUpdate
 
     // QHAdam recovers Adam when v2 = v1 = 1.
     iterate -= stepSize * ((((1 - v1) * gradient) + v1 * mDash) /
-               (arma::sqrt(((1 - v2) * (gradient % gradient)) +
-               v2 * vDash) + epsilon));
+      (arma::sqrt(((1 - v2) * (gradient % gradient)) +
+        v2 * vDash) + epsilon));
   }
 
   //! Get the value used to initialise the squared gradient parameter.
@@ -131,7 +131,7 @@ class QHAdamUpdate
   //! Modify the second quasi-hyperbolic term.
   double& V2() { return v2; }
 
- private:
+private:
   // The epsilon value used to initialise the squared gradient parameter.
   double epsilon;
 
@@ -147,14 +147,14 @@ class QHAdamUpdate
   // The exponential moving average of squared gradient values.
   arma::mat v;
 
-  // The number of iterations.
-  double iteration;
-
   // The first quasi-hyperbolic term.
   double v1;
 
   // The second quasi-hyperbolic term.
   double v2;
+
+  // The number of iterations.
+  double iteration;
 };
 
 } // namespace ens

--- a/inst/include/ensmallen_bits/qhadam/qhadam_update.hpp
+++ b/inst/include/ensmallen_bits/qhadam/qhadam_update.hpp
@@ -1,0 +1,162 @@
+/**
+ * @file qhadam_update.hpp
+ * @author Niteya Shah
+ *
+ * Implments the QHAdam Optimizer. QHAdam is a variant of Adam which introduces
+ * quasi hyperbolic moment terms to improve paramterisation and performance.
+ *
+ * ensmallen is free software; you may redistribute it and/or modify it under
+ * the terms of the 3-clause BSD license.  You should have received a copy of
+ * the 3-clause BSD license along with ensmallen.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef ENSMALLEN_ADAM_QHADAM_UPDATE_HPP
+#define ENSMALLEN_ADAM_QHADAM_UPDATE_HPP
+
+namespace ens {
+
+/**
+ * QHAdam is a optimising strategy based on the Quasi-Hyperbolic step when
+ * applied to the Adam Optimiser.QH updates can be considered to a weighted
+ * average of the momentum.QHAdam,based on its paramterisation can recover
+ * many algorithms such as NAdam and RMSProp.
+ *
+ * For more information, see the following.
+ *
+ * @code
+ * @inproceedings{ma2019qh,
+ *   title={Quasi-hyperbolic momentum and Adam for deep learning},
+ *   author={Jerry Ma and Denis Yarats},
+ *   booktitle={International Conference on Learning Representations},
+ *   year={2019}
+ * }
+ * @endcode
+ */
+class QHAdamUpdate
+{
+ public:
+  /**
+   * Construct the QHAdam update policy with the given parameters.
+   *
+   * @param epsilon The epsilon value used to initialise the squared gradient
+   *        parameter.
+   * @param beta1 The smoothing parameter.
+   * @param beta2 The second moment coefficient.
+   * @param v1 The first quasi-hyperbolic term.
+   * @param v1 The second quasi-hyperbolic term.
+   */
+  QHAdamUpdate(const double epsilon = 1e-8,
+               const double beta1 = 0.9,
+               const double beta2 = 0.999,
+               const double v1 = 0.7,
+               const double v2 = 1) :
+    epsilon(epsilon),
+    beta1(beta1),
+    beta2(beta2),
+    v1(v1),
+    v2(v2),
+    iteration(0)
+  {
+    // Nothing to do.
+  }
+
+  /**
+   * The Initialize method is called by SGD Optimizer method before the start of
+   * the iteration update process.
+   *
+   * @param rows Number of rows in the gradient matrix.
+   * @param cols Number of columns in the gradient matrix.
+   */
+  void Initialize(const size_t rows, const size_t cols)
+  {
+    m = arma::zeros<arma::mat>(rows, cols);
+    v = arma::zeros<arma::mat>(rows, cols);
+  }
+
+  /**
+   * Update step for QHAdam.
+   *
+   * @param iterate Parameters that minimize the function.
+   * @param stepSize Step size to be used for the given iteration.
+   * @param gradient The gradient matrix.
+   */
+  void Update(arma::mat& iterate,
+              const double stepSize,
+              const arma::mat& gradient)
+  {
+    // Increment the iteration counter variable.
+    ++iteration;
+
+    // And update the iterate.
+    m *= beta1;
+    m += (1 - beta1) * gradient;
+
+    v *= beta2;
+    v += (1 - beta2) * (gradient % gradient);
+
+    const double biasCorrection1 = 1.0 - std::pow(beta1, iteration);
+    const double biasCorrection2 = 1.0 - std::pow(beta2, iteration);
+
+    arma::mat mDash = m / biasCorrection1;
+    arma::mat vDash = v / biasCorrection2;
+
+    // QHAdam recovers Adam when v2 = v1 = 1.
+    iterate -= stepSize * ((((1 - v1) * gradient) + v1 * mDash) /
+               (arma::sqrt(((1 - v2) * (gradient % gradient)) +
+               v2 * vDash) + epsilon));
+  }
+
+  //! Get the value used to initialise the squared gradient parameter.
+  double Epsilon() const { return epsilon; }
+  //! Modify the value used to initialise the squared gradient parameter.
+  double& Epsilon() { return epsilon; }
+
+  //! Get the smoothing parameter.
+  double Beta1() const { return beta1; }
+  //! Modify the smoothing parameter.
+  double& Beta1() { return beta1; }
+
+  //! Get the second moment coefficient.
+  double Beta2() const { return beta2; }
+  //! Modify the second moment coefficient.
+  double& Beta2() { return beta2; }
+
+  //! Get the first quasi-hyperbolic term.
+  double V1() const { return v1; }
+  //! Modify the first quasi-hyperbolic term.
+  double& V1() { return v1; }
+
+  //! Get the second quasi-hyperbolic term.
+  double V2() const { return v2; }
+  //! Modify the second quasi-hyperbolic term.
+  double& V2() { return v2; }
+
+ private:
+  // The epsilon value used to initialise the squared gradient parameter.
+  double epsilon;
+
+  // The smoothing parameter.
+  double beta1;
+
+  // The second moment coefficient.
+  double beta2;
+
+  // The exponential moving average of gradient values.
+  arma::mat m;
+
+  // The exponential moving average of squared gradient values.
+  arma::mat v;
+
+  // The number of iterations.
+  double iteration;
+
+  // The first quasi-hyperbolic term.
+  double v1;
+
+  // The second quasi-hyperbolic term.
+  double v2;
+};
+
+} // namespace ens
+
+#endif

--- a/inst/include/ensmallen_bits/sgd/sgd.hpp
+++ b/inst/include/ensmallen_bits/sgd/sgd.hpp
@@ -19,6 +19,7 @@
 #include "update_policies/momentum_update.hpp"
 #include "update_policies/nesterov_momentum_update.hpp"
 #include "decay_policies/no_decay.hpp"
+#include "update_policies/quasi_hyperbolic_update.hpp"
 
 namespace ens {
 
@@ -191,6 +192,7 @@ using MomentumSGD = SGD<MomentumUpdate>;
 
 using NesterovMomentumSGD = SGD<NesterovMomentumUpdate>;
 
+using QHSGD = SGD<QHUpdate>;
 } // namespace ens
 
 // Include implementation.

--- a/inst/include/ensmallen_bits/sgd/update_policies/quasi_hyperbolic_update.hpp
+++ b/inst/include/ensmallen_bits/sgd/update_policies/quasi_hyperbolic_update.hpp
@@ -1,0 +1,101 @@
+/**
+ * @file quasi_hyperbolic_update.hpp
+ * @author Niteya Shah
+ *
+ * Quasi Hyperbolic Update for Stochastic Gradient Descent.
+ *
+ * ensmallen is free software; you may redistribute it and/or modify it under
+ * the terms of the 3-clause BSD license.  You should have received a copy of
+ * the 3-clause BSD license along with ensmallen.  If not, see
+ * http://www.opensource.org/licenses/BSD-3-Clause for more information.
+ */
+#ifndef ENSMALLEN_SGD_QH_UPDATE_HPP
+#define ENSMALLEN_SGD_QH_UPDATE_HPP
+
+namespace ens {
+
+/**
+ * Quasi Hyperbolic Update policy for Stochastic Gradient Descent (QHSGD).
+ *
+ * QHSGD is a update policy that is defined to be a parent of most update
+ * policies (most update policies can reconstructed from QHSGD). This allows
+ * this method to combine the features of many optimisers and provide better
+ * optimisation control.
+ *
+ * @code
+ * @inproceedings{ma2019qh,
+ *   title={Quasi-hyperbolic momentum and Adam for deep learning},
+ *   author={Jerry Ma and Denis Yarats},
+ *   booktitle={International Conference on Learning Representations},
+ *   year={2019}
+ * }
+ * @endcode
+ */
+class QHUpdate
+{
+ public:
+  /**
+   * Construct the Quasi Hyperbolic update policy with the given parameters.
+   *
+   * @param v The quasi hyperbolic term.
+   * @param momentum The momentum term.
+   */
+  QHUpdate(const double v = 0.7,
+           const double momentum = 0.999) :
+       momentum(momentum),
+       v(v)
+  {
+    // Nothing to do.
+  }
+
+  /**
+   * @param rows Number of rows in the gradient matrix.
+   * @param cols Number of columns in the gradient matrix.
+   */
+  void Initialize(const size_t rows, const size_t cols)
+  {
+    // Initialize an empty velocity matrix.
+    velocity = arma::zeros<arma::mat>(rows, cols);
+  }
+
+  /**
+   * Update step for QHSGD.
+   *
+   * @param iterate Parameters that minimize the function.
+   * @param stepSize Step size to be used for the given iteration.
+   * @param gradient The gradient matrix.
+   */
+  void Update(arma::mat& iterate,
+              const double stepSize,
+              const arma::mat& gradient)
+  {
+    velocity *= momentum;
+    velocity += (1 - momentum) * gradient;
+
+    iterate -= stepSize * ((1 - v) * gradient + v * velocity);
+  }
+
+  //! Get the value used to initialize the momentum coefficient.
+  double Momentum() const { return momentum; }
+  //! Modify the value used to initialize the momentum coefficient.
+  double& Momentum() { return momentum; }
+
+  //! Get the value used to initialize the momentum coefficient.
+  double V() const { return v; }
+  //! Modify the value used to initialize the momentum coefficient.
+  double& V() { return v; }
+
+ private:
+  // The velocity matrix.
+  arma::mat velocity;
+
+  // The Momentum coefficient.
+  double momentum;
+
+  //The quasi-hyperbolic term.
+  double v;
+};
+
+} // namespace ens
+
+#endif

--- a/inst/include/ensmallen_bits/spsa/spsa.hpp
+++ b/inst/include/ensmallen_bits/spsa/spsa.hpp
@@ -54,16 +54,13 @@ class SPSA
    * @param maxIterations Maximum number of iterations allowed (0 means no
    *     limit).
    * @param tolerance Maximum absolute tolerance to terminate algorithm.
-   * @param shuffle If true, the function order is shuffled; otherwise, each
-   *     function is visited in linear order.
    */
   SPSA(const double alpha = 0.602,
        const double gamma = 0.101,
        const double stepSize = 0.16,
        const double evaluationStepSize = 0.3,
        const size_t maxIterations = 100000,
-       const double tolerance = 1e-5,
-       const bool shuffle = true);
+       const double tolerance = 1e-5);
 
   template<typename DecomposableFunctionType>
   double Optimize(DecomposableFunctionType& function, arma::mat& iterate);
@@ -114,10 +111,6 @@ class SPSA
 
   //! The tolerance for termination.
   double tolerance;
-
-  //! Controls whether or not the individual functions are shuffled when
-  //! iterating.
-  bool shuffle;
 };
 
 } // namespace ens

--- a/inst/include/ensmallen_bits/spsa/spsa_impl.hpp
+++ b/inst/include/ensmallen_bits/spsa/spsa_impl.hpp
@@ -26,16 +26,14 @@ inline SPSA::SPSA(const double alpha,
                   const double stepSize,
                   const double evaluationStepSize,
                   const size_t maxIterations,
-                  const double tolerance,
-                  const bool shuffle) :
+                  const double tolerance) :
     alpha(alpha),
     gamma(gamma),
     stepSize(stepSize),
     evaluationStepSize(evaluationStepSize),
     ak(0.001 * maxIterations),
     maxIterations(maxIterations),
-    tolerance(tolerance),
-    shuffle(shuffle)
+    tolerance(tolerance)
 { /* Nothing to do. */ }
 
 template<typename ArbitraryFunctionType>


### PR DESCRIPTION
Made two modifications to fix:

```
 ../inst/include/ensmallen_bits/qhadam/qhadam_update.hpp:57:5:
 warning: field 'v2' will be initialized after field 'iteration' [-Wreorder]

 ../inst/include/ensmallen_bits/spsa/spsa.hpp:120:8:
warning: private field 'shuffle' is not used [-Wunused-private-field]
  bool shuffle;
```

Sent two patches upstream to address the issue: 

- mlpack/ensmallen#115: for the above issues
- mlpack/ensmallen#116: added minimal style checks to prevent repeat issues.
