### PR TITLE
Revert "Fix version check in auto PR update"

### DIFF
--- a/.github/workflows/upstream-refresh.yaml
+++ b/.github/workflows/upstream-refresh.yaml
@@ -28,6 +28,7 @@ jobs:
       - name: Update Ensmallen
         if: steps.ensmallen-lib.outputs.current_tag != steps.ensmallen-lib.outputs.release_tag
         env:
+          CURRENT_TAG: ${{ steps.ensmallen-lib.outputs.current_tag }}
           RELEASE_TAG: ${{ steps.ensmallen-lib.outputs.release_tag }}
           RELEASE_DATE: ${{ steps.ensmallen-lib.outputs.release_date }}
         run: |

--- a/.github/workflows/upstream-refresh.yaml
+++ b/.github/workflows/upstream-refresh.yaml
@@ -18,9 +18,9 @@ jobs:
           echo ::set-output name=release_tag::$(echo $ENSMALLEN_RELEASE_VERSION)
           echo ::set-output name=release_date::$(echo $ENSMALLEN_RELEASE_DATE)
           # Extract out version information from git repository
-          ENSMALLEN_VERSION_MAJOR=$(grep -i ".*#define ENS_VERSION_MAJOR.*" inst/include/ensmallen_bits/ens_version.hpp | sed 's/^.*#define[ ]ENS_VERSION_MAJOR[ ]*\([0-9]*\).*$/\1/')
-          ENSMALLEN_VERSION_MINOR=$(grep -i ".*#define ENS_VERSION_MINOR.*" inst/include/ensmallen_bits/ens_version.hpp | sed 's/^.*#define[ ]ENS_VERSION_MINOR[ ]*\([0-9]*\).*$/\1/')
-          ENSMALLEN_VERSION_PATCH=$(grep -i ".*#define ENS_VERSION_PATCH.*" inst/include/ensmallen_bits/ens_version.hpp | sed 's/^.*#define[ ]ENS_VERSION_PATCH[ ]*\([0-9]*\).*$/\1/')
+          ENSMALLEN_VERSION_MAJOR=$(grep -i ".*#define ENS_VERSION_MAJOR.*" inst/include/ensmallen_bits/ens_version.hpp | grep -o "[0-9]*")
+          ENSMALLEN_VERSION_MINOR=$(grep -i ".*#define ENS_VERSION_MINOR.*" inst/include/ensmallen_bits/ens_version.hpp | grep -o "[0-9]*")
+          ENSMALLEN_VERSION_PATCH=$(grep -i ".*#define ENS_VERSION_PATCH.*" inst/include/ensmallen_bits/ens_version.hpp | grep -o "[0-9]*")
           # Combine values to match release tag information
           ENSMALLEN_VERSION_VALUE=${ENSMALLEN_VERSION_MAJOR}.${ENSMALLEN_VERSION_MINOR}.${ENSMALLEN_VERSION_PATCH}
           # Set the current release tag
@@ -28,7 +28,6 @@ jobs:
       - name: Update Ensmallen
         if: steps.ensmallen-lib.outputs.current_tag != steps.ensmallen-lib.outputs.release_tag
         env:
-          CURRENT_TAG: ${{ steps.ensmallen-lib.outputs.current_tag }}
           RELEASE_TAG: ${{ steps.ensmallen-lib.outputs.release_tag }}
           RELEASE_DATE: ${{ steps.ensmallen-lib.outputs.release_date }}
         run: |

--- a/.github/workflows/upstream-refresh.yaml
+++ b/.github/workflows/upstream-refresh.yaml
@@ -1,8 +1,8 @@
 name: Update Ensmallen
 on:
   workflow_dispatch:
-  schedule:
-    - cron:  '0 10 * * *'
+  #schedule:
+  #  - cron:  '0 10 * * *'
 jobs:
   updateEnsmallen:
     runs-on: ubuntu-latest

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,7 +1,3 @@
-2020-08-23  James Balamuta  <balamut2@illinois.edu>
-
-	* .github/workflows/upstream-refresh.yaml: Fix version check failure.
-
 2020-08-22  James Balamuta  <balamut2@illinois.edu>
 
 	* DESCRIPTION (Version): Release 2.14.1
@@ -15,7 +11,7 @@
 
 	* .github/workflows/upstream-refresh.yaml: Fix NEWS.md entry formatting
 	issues.
-
+  
 2020-08-21  James Balamuta  <balamut2@illinois.edu>
 
 	* .github/workflows/upstream-refresh.yaml: Add GitHub Action to

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@
   CRAN's check grid (`oldrel`, `release`, `devel`). ([#29](https://github.com/coatless/rcppensmallen/pull/29), 
   [#32](https://github.com/coatless/rcppensmallen/pull/32))
 - Added a GitHub Action to automatically create a PR with the new version of
-  Ensmallen when a new release is detected. ([#30](https://github.com/coatless/rcppensmallen/pull/30), [#33](https://github.com/coatless/rcppensmallen/pull/33), [#35](https://github.com/coatless/rcppensmallen/pull/35))
+  Ensmallen when a new release is detected. ([#30](https://github.com/coatless/rcppensmallen/pull/30), [#33](https://github.com/coatless/rcppensmallen/pull/33))
 
 # RcppEnsmallen 0.2.13.0.1
 


### PR DESCRIPTION
Reverts coatless/rcppensmallen#35 and disables the CRON job run.

The issue is upstream with the version number in the tagged release.

Details in: https://github.com/mlpack/ensmallen/issues/222#issuecomment-679241986