### PR TITLE
Keep bundled ensmallen header paths within CRAN's 100-byte limit

### DIFF
--- a/.github/workflows/upstream-refresh.yaml
+++ b/.github/workflows/upstream-refresh.yaml
@@ -42,6 +42,11 @@ jobs:
           # Extract the update files directly into the include directory.
           # Strip away two levels ${TAR_PREFIX_DIR}/include.
           tar -xzf $RELEASE_TAG -C inst/include/ --strip-components=2 ${TAR_PREFIX_DIR}/include/ensmallen_bits ${TAR_PREFIX_DIR}/include/ensmallen.hpp
+          # Shorten bundled header paths that exceed the 100-byte tarball limit
+          # (R CMD check "portable file names"). Reapplied on every upgrade; the
+          # step fails if a new upstream path exceeds the limit so a mapping can
+          # be added to tools/ensmallen-path-remaps.tsv.
+          bash tools/apply-ensmallen-path-remaps.sh
           # Extract HISTORY.md file into the tool directory for a comparison.
           # Strip away one-level ${TAR_PREFIX_DIR}
           tar -xzf $RELEASE_TAG -C tools/ --strip-components=1 ${TAR_PREFIX_DIR}/HISTORY.md

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+2026-07-18  James Balamuta  <balamut2@illinois.edu>
+
+	* inst/include/ensmallen_bits/delta_bar_delta/update_policies/momentum_dbd_update.hpp:
+	Renamed from momentum_delta_bar_delta_update.hpp to keep the packaged path
+	within the 100-byte portable-file-name limit.
+	* inst/include/ensmallen_bits/delta_bar_delta/momentum_delta_bar_delta.hpp: Update include.
+	* tools/ensmallen-path-remaps.tsv: New; manifest of bundled header path remaps.
+	* tools/apply-ensmallen-path-remaps.sh: New; apply remaps and fail if any path exceeds 100 bytes.
+	* .github/workflows/upstream-refresh.yaml: Apply path remaps after each ensmallen upgrade.
+
 2026-04-24  James Balamuta  <balamut2@illinois.edu>
 
 	* DESCRIPTION (Version): Release 3.11.0

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,9 @@
   - Fix an off-by-one bug where the actual number of executed iterations was one
     fewer than the specified `maxIterations`
     ([#443](https://github.com/mlpack/ensmallen/pull/443)).
+- Renamed the bundled 'ensmallen' `MomentumDeltaBarDelta` update header so every
+  packaged file path stays within CRAN's 100-byte tarball limit, and added an
+  automated remap step so future 'ensmallen' upgrades keep to it.
 
 # RcppEnsmallen 0.3.10.0.1
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,32 +1,32 @@
 ## Test environments
 
-* local macOS install, R 4.4.2
-* ubuntu 20.04 (with GitHub Actions), R 4.4.2
-* win-builder (devel and release)
+* local: macOS 26.5 "Tahoe" (aarch64), R 4.6.1
+* GitHub Actions:
+  - macos-latest, R release
+  - windows-latest, R release
+  - ubuntu-latest, R devel / release / oldrel-1
 
 ## R CMD check results
 
-0 errors | 0 warnings | 0 note
+0 errors | 0 warnings | 0 notes
 
 ## Reverse dependencies
 
-With this update, only `sparsevb` failed to install due to the C++14 requirement. 
-This is due to the `RcppEnsmallen` package now requiring C++14. I have 
-contacted the maintainer of `sparsevb` to update their package to work with
-C++14 and provided a patch to do so. However, I have not received a response
-yet. 
+We checked all 5 reverse dependencies (mlpack, PJFM, Racmacs,
+rcppmlpackexamples, sparsevb), comparing R CMD check results across the CRAN
+and development versions of this package.
 
-> https://gitlab.com/gclara/varpack/-/issues/2
-> https://gitlab.com/gclara/varpack/-/merge_requests/1
-
-Per discussions with Kurt, it is fine to temporarily break `sparsevb` in order
-to allow `mlpack` to be updated to the latest version.
+ * We saw 0 new problems
+ * We failed to check 0 packages
 
 ### revdepcheck results
 
-✔ HDJM 0.1.0                             ── E: 0     | W: 0     | N: 0    
-✔ mlpack 4.5.0                           ── E: 0     | W: 1     | N: 1    
-✔ PJFM 0.1.0                             ── E: 0     | W: 0     | N: 0    
-✔ Racmacs 1.2.9                          ── E: 0     | W: 0     | N: 1    
-I sparsevb 0.1.0                         ── E: 0  +1 | W: 0     | N: 0-1  
-✔ VBJM 0.1.0                             ── E: 0     | W: 0     | N: 0   
+    ✔ mlpack 4.8.0                ── E: 0 | W: 1 | N: 0
+    ✔ PJFM 0.1.0                  ── E: 0 | W: 0 | N: 1
+    ✔ Racmacs 1.2.10              ── E: 0 | W: 0 | N: 0
+    ✔ rcppmlpackexamples 0.0.1    ── E: 0 | W: 1 | N: 1
+    ✔ sparsevb 0.1.1             ── E: 0 | W: 0 | N: 1
+
+The warnings and notes shown above are pre-existing in each reverse
+dependency (they appear identically against the CRAN and development
+versions of RcppEnsmallen) and are therefore unrelated to this update.

--- a/inst/include/ensmallen_bits/delta_bar_delta/momentum_delta_bar_delta.hpp
+++ b/inst/include/ensmallen_bits/delta_bar_delta/momentum_delta_bar_delta.hpp
@@ -13,7 +13,7 @@
 #define ENSMALLEN_MOMENTUM_DELTA_BAR_DELTA_HPP
 
 #include <ensmallen_bits/gradient_descent/gradient_descent.hpp>
-#include "update_policies/momentum_delta_bar_delta_update.hpp"
+#include "update_policies/momentum_dbd_update.hpp"
 
 namespace ens {
 

--- a/inst/include/ensmallen_bits/delta_bar_delta/update_policies/momentum_dbd_update.hpp
+++ b/inst/include/ensmallen_bits/delta_bar_delta/update_policies/momentum_dbd_update.hpp
@@ -1,5 +1,5 @@
 /**
- * @file momentum_delta_bar_delta_update.hpp
+ * @file momentum_dbd_update.hpp
  * @author Ranjodh Singh
  *
  * MomentumDeltaBarDelta update policy for Gradient Descent.

--- a/tools/apply-ensmallen-path-remaps.sh
+++ b/tools/apply-ensmallen-path-remaps.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+#
+# Apply permanent path remaps to the bundled 'ensmallen' headers so every file
+# path in the built source tarball stays within R's 100-byte "portable file
+# names" limit.
+#
+# The "Update Ensmallen" workflow calls this right after extracting a new
+# upstream release (which wipes and re-extracts inst/include/ensmallen_bits
+# verbatim). It is also safe to run locally and is idempotent.
+#
+# Run from the package root:  bash tools/apply-ensmallen-path-remaps.sh
+#
+# Manifest: tools/ensmallen-path-remaps.tsv  (old<TAB>new, relative to inst/include/)
+#
+set -euo pipefail
+
+INCLUDE_DIR="inst/include"
+MANIFEST="tools/ensmallen-path-remaps.tsv"
+PKG_PREFIX="RcppEnsmallen"   # tarball top-level dir; paths ship as PKG_PREFIX/<relpath>
+MAX_BYTES=100
+
+if [ ! -f "$MANIFEST" ]; then
+  echo "ERROR: manifest not found: $MANIFEST (run from the package root)" >&2
+  exit 1
+fi
+
+# --- Apply each remap -------------------------------------------------------
+while IFS=$'\t' read -r old new _rest; do
+  # Skip blank lines and comments.
+  case "${old:-}" in
+    ''|\#*) continue ;;
+  esac
+  if [ -z "${new:-}" ]; then
+    echo "ERROR: manifest entry has no target: '$old'" >&2
+    exit 1
+  fi
+
+  old_path="$INCLUDE_DIR/$old"
+  new_path="$INCLUDE_DIR/$new"
+  old_base="$(basename "$old")"
+  new_base="$(basename "$new")"
+
+  if [ -f "$new_path" ] && [ ! -f "$old_path" ]; then
+    echo "= already remapped: $old_base -> $new_base"
+  elif [ -f "$old_path" ]; then
+    mkdir -p "$(dirname "$new_path")"
+    mv "$old_path" "$new_path"
+    echo "> renamed: $old -> $new"
+  else
+    echo "ERROR: source header not found (upstream layout changed?): $old_path" >&2
+    exit 1
+  fi
+
+  # Rewrite #include references (and the @file doc comment) by basename.
+  # ensmallen header basenames are globally unique, so a basename substitution
+  # is safe and catches both relative and root-relative include paths.
+  if [ "$old_base" != "$new_base" ]; then
+    files="$(grep -rlF --include='*.hpp' "$old_base" "$INCLUDE_DIR" 2>/dev/null || true)"
+    if [ -n "$files" ]; then
+      pat="${old_base//./\\.}"   # escape dots for the sed pattern
+      printf '%s\n' "$files" | while IFS= read -r f; do
+        [ -n "$f" ] || continue
+        sed -i.bak "s/${pat}/${new_base}/g" "$f"
+        rm -f "$f.bak"
+        echo "  patched include(s) in: ${f#"$INCLUDE_DIR"/}"
+      done
+    fi
+  fi
+done < "$MANIFEST"
+
+# --- Guard: no shipped path may exceed MAX_BYTES ----------------------------
+echo "checking inst/ paths are <= $MAX_BYTES bytes ..."
+violations=0
+while IFS= read -r f; do
+  full="$PKG_PREFIX/$f"
+  n="$(printf '%s' "$full" | wc -c | tr -d '[:space:]')"
+  if [ "$n" -gt "$MAX_BYTES" ]; then
+    echo "TOO LONG ($n bytes): $full" >&2
+    violations=$((violations + 1))
+  fi
+done < <(find inst -type f)
+
+if [ "$violations" -gt 0 ]; then
+  echo "ERROR: $violations path(s) exceed $MAX_BYTES bytes." >&2
+  echo "       Add a shortened mapping for each to $MANIFEST and re-run." >&2
+  exit 1
+fi
+echo "OK: all inst/ paths are within $MAX_BYTES bytes."

--- a/tools/ensmallen-path-remaps.tsv
+++ b/tools/ensmallen-path-remaps.tsv
@@ -1,0 +1,16 @@
+# Permanent path remaps for the bundled 'ensmallen' headers.
+#
+# Some upstream header paths exceed the 100-byte limit that R CMD check enforces
+# for portable tarball file names ("checking for portable file names ... NOTE").
+# The daily "Update Ensmallen" workflow re-extracts ensmallen verbatim, so any
+# rename must be reapplied automatically after each upgrade.
+# tools/apply-ensmallen-path-remaps.sh consumes this table.
+#
+# Format: one remap per line, TAB-separated, both paths relative to inst/include/.
+#   <old-relpath><TAB><new-relpath>
+# Only the final component (file name) is shortened; directories are preserved.
+# Lines starting with '#' and blank lines are ignored. When the guard reports a
+# new >100-byte path, add a shortened mapping here.
+#
+# old-relpath	new-relpath
+ensmallen_bits/delta_bar_delta/update_policies/momentum_delta_bar_delta_update.hpp	ensmallen_bits/delta_bar_delta/update_policies/momentum_dbd_update.hpp


### PR DESCRIPTION
ensmallen 3.11.0 ships a header whose packaged path is 109 bytes, over CRAN's 100-byte tarball path limit ("non-portable file names" NOTE).

- Rename `ensmallen_bits/delta_bar_delta/update_policies/momentum_delta_bar_delta_update.hpp` → `momentum_dbd_update.hpp` (97 bytes) and update its `#include`.
- Add `tools/ensmallen-path-remaps.tsv` (old→new manifest) and `tools/apply-ensmallen-path-remaps.sh`, which renames per the manifest and fails if any `inst/` path exceeds 100 bytes.
- Run the applier after each extraction in the Update Ensmallen workflow, so upgrades stay within the limit — a new over-long upstream path fails the auto-PR until a mapping is added.
- Update NEWS.md, ChangeLog, and cran-comments.
